### PR TITLE
Preserve local/work folder structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,9 @@
+# Local Python artifacts
 **/__pycache__/
+
+# IDE config and metadata
+*.iml
+
+# Only preserve folder structure
+local/work/**/*
+!local/work/.gitkeep


### PR DESCRIPTION
Prevent users from needing to create local/work, and avoid versioning contents