### PR TITLE
Fix single line modules

### DIFF
--- a/site/hive/mqtt/zmq_stt_handler.py
+++ b/site/hive/mqtt/zmq_stt_handler.py
@@ -62,8 +62,8 @@ class STTSession:
                 response_format="verbose_json",
                 timestamp_granularities=["word"])
             resp.speech = transcript.text
-            min_start = min(d.start for d in transcript.words)
-            max_end = max(d.end for d in transcript.words)
+            min_start = min(d.start for d in transcript.words) if transcript.words else 0
+            max_end = max(d.end for d in transcript.words) if transcript.words else 0
             resp.start_timestamp = self._start_ts + int(min_start*1000)
             resp.end_timestamp = self._start_ts + int(max_end*1000)
             logger.info(f'STT-FINAL: {transcript.text}')


### PR DESCRIPTION
- Changed exit_module to launch to first exit. 
- Noted in testing (and confirmed in robot code), the exit_module action destroys the response line.  So using launch to first exit is the only way to ensure convos that exit on the prompt actually work
- Fixed exception when transcription words are empty