### PR TITLE
Added ability to set bots to 'unpairing' to force them back to QR.

### DIFF
--- a/site/hive/models.py
+++ b/site/hive/models.py
@@ -47,6 +47,11 @@ class MoxieDevice(models.Model):
     robot_config = models.JSONField(null=True, blank=True)
     robot_settings = models.JSONField(null=True, blank=True)
 
+    def is_paired(self):
+        if self.robot_config:
+            return not (self.robot_config.get('pairing_status') == 'unpairing')
+        return True
+
     def __str__(self):
         return self.name if self.name else self.device_id
 

--- a/site/hive/templates/hive/dashboard.html
+++ b/site/hive/templates/hive/dashboard.html
@@ -20,7 +20,11 @@
     {% else %}
     <span class="badge text-bg-secondary">Offline</span> {{device.last_disconnect|timesince}}
     {% endif %}
-  </td><td><a href="{% url 'hive:moxie' device.pk %}">{{device}}</a></td><td>{{device.schedule}}</td>
+  </td><td><a href="{% url 'hive:moxie' device.pk %}">{{device}}</a>
+    {% if not device.is_paired %}
+    <span class="badge text-bg-danger">Unpaired</span>
+    {% endif %}
+  </td><td>{{device.schedule}}</td>
   <td>
     {% if device.robot_config.wake_button_enabled and device.device_id in live %}
     <a class="btn btn-success btn-sm" href="{% url 'hive:moxie_wake' device.pk %}">Wake</a>

--- a/site/hive/templates/hive/moxie.html
+++ b/site/hive/templates/hive/moxie.html
@@ -10,6 +10,12 @@
   <table class="table">
     <tr><th>Name</th><td><input type="text" class="form-control" name="moxie_name" value="{{object.name}}"></td></tr>
     <tr><th>Device ID</th><td>{{object.device_id}}</td></tr>
+    <tr><th>Device Pairing</th><td>
+      <select name="pairing_status">
+          <option value="paired" {% if object.is_paired %}selected{% endif %}>Paired/Allowed</option>
+          <option value="unpairing" {% if not object.is_paired %}selected{% endif %}>Unpaired/Blocked</option>
+      </select>
+    </td></tr>
     <tr><th>Mentor Name</th><td><input type="text" class="form-control" name="nickname" value="{{active_config.child_pii.nickname}}"></td></tr>
     <tr><th>Schedule</th><td>
         <select name="schedule">

--- a/site/hive/views.py
+++ b/site/hive/views.py
@@ -178,6 +178,8 @@ def moxie_edit(request, pk):
             device.robot_config["child_pii"]["nickname"] = request.POST["nickname"]
         else:
             device.robot_config["child_pii"] = { "nickname": request.POST["nickname"] }
+        # pairing/unpairing
+        device.robot_config["pairing_status"] = request.POST["pairing_status"]
         device.save()
         get_instance().handle_config_updated(device)
     except MoxieDevice.DoesNotExist as e:


### PR DESCRIPTION
- Added selection to Moxie edit to unpair or re-pair a bot.  When unpairing state is set, Moxie will return to QR reading view.
- Show unpaired state on dashboard
![image](https://github.com/user-attachments/assets/b5936e3a-5f02-4fd4-8b1c-654b2e6ea750)
