### PR TITLE
Multiple Content IDs per module, and WAKEUP_LAUNCHER

### DIFF
--- a/MoxieOverview.md
+++ b/MoxieOverview.md
@@ -105,6 +105,7 @@ to the default schedule, but doesn't have Tips and Tricks or Systems Check modul
 ## Keys
 
 * provided_schedule - a list of module_ids with or without content_ids
+* wake_module - the module ID for an alternate wakeup module (needs all wakeup content IDs)
 * chat_request - the module/content ID when user asks "moxie let's chat"
 * end_of_session - a block describing what to do when the schedule is done, where you do the `end_module` followed by `chat_count` of the `chat_module` before being forced to sleep
 * generate - rules to automatically extend the schedule
@@ -116,6 +117,16 @@ to the default schedule, but doesn't have Tips and Tricks or Systems Check modul
 * module_count - Number of modules to append to the schedule
 * extra_modules - A list of user created module/content IDs that can be scheduled in addition to the default content modules
 * excluded_module_ids - A list of module_id values that should *not* end up in the schedule
+
+### Wakeup Module
+
+If you want to wake Moxie up directly into the schedule, without having to go through the normal
+wakeup routine first, you may create or use a custom module.  A default version is provided called
+WAKEUP_LAUNCHER.  To use this, add this to your schedule:
+
+```
+"wake_module": { "module_id": "WAKEUP_LAUNCHER" },
+```
 
 # Configuration and Settings
 

--- a/site/data/default_conversations.json
+++ b/site/data/default_conversations.json
@@ -51,5 +51,14 @@
       "prompt": "Not used",
       "opener": "I just wanted to say this one line.",
       "max_volleys": 0
+    },
+    { 
+      "name": "Wakeup Launcher",
+      "source_version": 1,
+      "module_id": "WAKEUP_LAUNCHER",
+      "content_id": "ftue|more_10|less_10|first_time_today|scheduled",
+      "prompt": "Not used",
+      "opener": ".",
+      "max_volleys": 0
     }
 ]

--- a/site/hive/mqtt/moxie_remote_chat.py
+++ b/site/hive/mqtt/moxie_remote_chat.py
@@ -188,13 +188,16 @@ class RemoteChat:
         new_modules = {}
         mod_map = {}
         for chat in SinglePromptChat.objects.all():
-            new_modules[f'{chat.module_id}/{chat.content_id}'] = { 'xtor': SinglePromptDBChatSession, 'params': { 'pk': chat.pk } }
-            logger.debug(f'Registering {chat.module_id}/{chat.content_id}')
-            # Group content IDs under module IDs
-            if chat.module_id in mod_map:
-                mod_map[chat.module_id].append(chat.content_id)
-            else:
-                mod_map[chat.module_id] = [ chat.content_id ]
+            # one module can support many content IDs, separated by | like openers
+            cid_list = chat.content_id.split('|')
+            for content_id in cid_list:
+                new_modules[f'{chat.module_id}/{content_id}'] = { 'xtor': SinglePromptDBChatSession, 'params': { 'pk': chat.pk } }
+                logger.debug(f'Registering {chat.module_id}/{content_id}')
+                # Group content IDs under module IDs
+                if chat.module_id in mod_map:
+                    mod_map[chat.module_id].append(content_id)
+                else:
+                    mod_map[chat.module_id] = [ content_id ]
         # Models/content IDs into the module info schema - bare bones mandatory fields only
         mlist = []
         for mod in mod_map.keys():
@@ -210,6 +213,8 @@ class RemoteChat:
     def check_global(self, rcr):
         return self._global_responses.check_global(rcr) if _ENABLE_GLOBAL_COMMANDS else None
         
+    def on_chat_complete(self, id, device_id, session):
+        logger.info(f'Chat Session Complete: {id}')
 
     # Get the current or a new session for this device for this module/content ID pair
     def get_session(self, device_id, id, maker):
@@ -217,6 +222,8 @@ class RemoteChat:
         if device_id in self._device_sessions:
             if self._device_sessions[device_id]['id'] == id:
                 return self._device_sessions[device_id]['session']
+            else:
+                self.on_chat_complete(device_id, id, self._device_sessions[device_id]['session'])
 
         # new session needed
         new_session = { 'id': id, 'session': maker['xtor'](**maker['params']) }
@@ -299,7 +306,8 @@ class RemoteChat:
         else:
             session_reset = False
             if device_id in self._device_sessions:
-                del self._device_sessions[device_id]
+                session = self._device_sessions.pop(device_id, None)
+                self.on_chat_complete(device_id, id, session)
                 session_reset = True
             if cmd != 'notify':
                 logger.debug(f'Ignoring request for other module: {id} SessionReset:{session_reset}')

--- a/site/hive/mqtt/moxie_remote_chat.py
+++ b/site/hive/mqtt/moxie_remote_chat.py
@@ -213,7 +213,7 @@ class RemoteChat:
     def check_global(self, rcr):
         return self._global_responses.check_global(rcr) if _ENABLE_GLOBAL_COMMANDS else None
         
-    def on_chat_complete(self, id, device_id, session):
+    def on_chat_complete(self, device_id, id, session):
         logger.info(f'Chat Session Complete: {id}')
 
     # Get the current or a new session for this device for this module/content ID pair


### PR DESCRIPTION
- Adds the ability for one SinglePromptConversation to have multiple content IDs separated by |, which is useful for things like...
- Adds WAKEUP_LAUNCHER, a single line, silent module that immediately completes and brings user into the first item in the schedule